### PR TITLE
Potential fix for code scanning alert no. 19: Flask app is run in debug mode

### DIFF
--- a/src/cloud-services/src/modules/module-name/handlers/ProductHandler.py
+++ b/src/cloud-services/src/modules/module-name/handlers/ProductHandler.py
@@ -65,4 +65,6 @@ def delete_product(product_id):
     return product_handler.delete_product(product_id)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/Fast677/Alphapp/security/code-scanning/19](https://github.com/Fast677/Alphapp/security/code-scanning/19)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

1. Import the `os` module to access environment variables.
2. Modify the `app.run` call to set the `debug` parameter based on an environment variable.
3. Set a default value for the environment variable to ensure debug mode is off by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
